### PR TITLE
Fix Missing Icons

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -401,9 +401,9 @@ class WaterHeaterCard extends LitElement {
                   <ha-icon-button
                     ?disabled=${maxTemp && value >= maxTemp}
                     class="thermostat-trigger"
-                    icon=${row ? ICONS.PLUS : ICONS.UP}
                     @click="${() => this.setTemperature(this._stepSize, field)}"
                   >
+                    <ha-icon icon="${row ? ICONS.PLUS : ICONS.UP}"></ha-icon>
                   </ha-icon-button>
 
                   <div
@@ -422,10 +422,10 @@ class WaterHeaterCard extends LitElement {
                   <ha-icon-button
                     ?disabled=${minTemp && value <= minTemp}
                     class="thermostat-trigger"
-                    icon=${row ? ICONS.MINUS : ICONS.DOWN}
                     @click="${() =>
                       this.setTemperature(-this._stepSize, field)}"
                   >
+                    <ha-icon icon="${row ? ICONS.MINUS : ICONS.DOWN}"></ha-icon>
                   </ha-icon-button>
                 </div>
               </div>

--- a/water-heater-card.js
+++ b/water-heater-card.js
@@ -1985,13 +1985,10 @@
       ).map(
         ([t, e]) =>
           V`<div class="main"><div class="current-wrapper ${_}"><ha-icon-button ?disabled="${l &&
-            e >= l}" class="thermostat-trigger" icon="${
+            e >= l}" class="thermostat-trigger" @click="${() =>
+            this.setTemperature(this._stepSize, t)}"><ha-icon icon="${
             g ? ht : ut
-          }" @click="${() =>
-            this.setTemperature(
-              this._stepSize,
-              t
-            )}"></ha-icon-button><div @click="${() =>
+          }"></ha-icon></ha-icon-button><div @click="${() =>
             this.openEntityPopover()}" class="current--value-wrapper"><h3 class="current--value ${
             i ? 'updating' : ''
           }">${(function(t, { decimals: e = 1, fallback: n = 'N/A' } = {}) {
@@ -2004,13 +2001,10 @@
             e,
             r
           )}</h3><span class="current--unit">${p}</span></div><ha-icon-button ?disabled="${c &&
-            e <= c}" class="thermostat-trigger" icon="${
+            e <= c}" class="thermostat-trigger" @click="${() =>
+            this.setTemperature(-this._stepSize, t)}"><ha-icon icon="${
             g ? pt : dt
-          }" @click="${() =>
-            this.setTemperature(
-              -this._stepSize,
-              t
-            )}"></ha-icon-button></div></div>`
+          }"></ha-icon></ha-icon-button></div></div>`
       )}</section>${this.modes.map(t => this.renderModeType(t))}</ha-card>`
     }
     renderHeader() {


### PR DESCRIPTION
Home Assistant changed the way icons work in buttons a while back, this PR fixes it by passing the icon into the default slot of the button.

The issue was originally reported here: #9 

![Screenshot_20220605-111714](https://user-images.githubusercontent.com/16567259/172057572-f6807b5a-5f34-48ce-a039-a67f8a45aff4.png)

Let me know if I missed anything!